### PR TITLE
Update Stirling-PDF v2.4.3 - Add Built-in Login Authentication

### DIFF
--- a/Apps/Stirling-PDF/docker-compose.yml
+++ b/Apps/Stirling-PDF/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: docker.stirlingpdf.com/stirlingtools/stirling-pdf:2.4.3
     container_name: stirling-pdf
     restart: unless-stopped
+    networks:
+      - pcs
     expose:
       - 80
     volumes:
@@ -20,10 +22,12 @@ services:
       PGID: 0
       PUID: 0
       TZ: $TZ
-      DOCKER_ENABLE_SECURITY: false
-      SECURITY_ENABLELOGIN: false
+      DOCKER_ENABLE_SECURITY: true
+      SECURITY_ENABLELOGIN: true
+      SECURITY_INITIALLOGIN_USERNAME: admin
+      SECURITY_INITIALLOGIN_PASSWORD: $default_pwd
       DISABLE_ADDITIONAL_FEATURES: true
-      SYSTEM_DEFAULTLOCALE: en_US
+      SYSTEM_DEFAULTLOCALE: $TZ
       INSTALL_BOOK_AND_ADVANCED_HTML_OPS: false
       TMPDIR: /tmp
       # Optimized Java memory management - prevents OOM errors and improves stability
@@ -38,6 +42,10 @@ services:
           memory: 2G  # Reserve minimum memory
     cpu_shares: 50  # Standard application priority
 
+networks:
+  pcs:
+    external: true
+
 x-casaos:
   architectures:
     - amd64
@@ -47,12 +55,6 @@ x-casaos:
   author: Yundera Team
   category: Office
   developer: Stirling Tools
-  pre-install-cmd: |
-    docker run --rm -v /DATA/AppData/$AppID:/data ubuntu:22.04 sh -c '
-      mkdir -p /data/tessdata /data/configs /data/logs /data/customFiles /data/pipeline /data/tmp &&
-      chmod -R 777 /data &&
-      echo "Directories created and permissions set successfully"
-    '
   description:
     en_us: |
       **Your complete PDF toolkit - everything you need to work with PDF files, right from your web browser.**
@@ -184,8 +186,12 @@ x-casaos:
         **⏰ Setup Time:**
         This app takes about 5-10 minutes to set up after installation. Please be patient and wait before trying to access it.
 
-        **🔓 No Login Required:**
-        This app is configured without authentication for easier access. All PDF processing happens locally on your server. (See rationale.md for security justification)
+        **🔒 Login Required:**
+        This app has built-in login protection for security.
+        • Username: `admin`
+        • Password: Auto-generated (same as $default_pwd)
+
+        After installation, visit the app and log in with the credentials above.
 
         **✨ Features Available:**
         • Split, merge, and organize PDFs
@@ -212,8 +218,12 @@ x-casaos:
         **⏰ 설정 시간:**
         이 앱은 설치 후 설정이 완료되기까지 약 5-10분이 걸립니다. 인내심을 갖고 접속하기 전에 기다려 주세요.
 
-        **🔓 로그인 필요 없음:**
-        이 앱은 쉬운 접근을 위해 인증 없이 구성되었습니다. 모든 PDF 처리는 로컬 서버에서 이루어집니다. (보안 정당성은 rationale.md 참조)
+        **🔒 로그인 필요:**
+        이 앱은 보안을 위해 내장 로그인으로 보호됩니다.
+        • 사용자명: `admin`
+        • 비밀번호: 자동 생성됨 ($default_pwd와 동일)
+
+        설치 후 앱을 방문하여 위 자격 증명으로 로그인하세요.
 
         **✨ 사용 가능한 기능:**
         • PDF 분할, 병합, 정리
@@ -240,8 +250,12 @@ x-casaos:
         **⏰ 设置时间:**
         此应用在安装后需要约5-10分钟来完成设置。请耐心等待,在尝试访问之前请等待。
 
-        **🔓 无需登录:**
-        此应用配置为无身份验证,以便于访问。所有PDF处理都在本地服务器上进行。(安全性理由见rationale.md)
+        **🔒 需要登录:**
+        此应用具有内置登录保护以确保安全。
+        • 用户名：`admin`
+        • 密码：自动生成（与$default_pwd相同）
+
+        安装后，访问应用并使用上述凭据登录。
 
         **✨ 可用功能:**
         • PDF拆分、合并和整理
@@ -268,8 +282,12 @@ x-casaos:
         **⏰ Temps d'installation :**
         Cette application prend environ 5-10 minutes pour s'installer après l'installation. Veuillez être patient et attendre avant d'essayer d'y accéder.
 
-        **🔓 Aucune connexion requise :**
-        Cette application est configurée sans authentification pour un accès plus facile. Tout le traitement PDF se fait localement sur votre serveur. (Voir rationale.md pour la justification de sécurité)
+        **🔒 Connexion requise :**
+        Cette application dispose d'une protection de connexion intégrée pour la sécurité.
+        • Nom d'utilisateur : `admin`
+        • Mot de passe : Généré automatiquement (identique à $default_pwd)
+
+        Après l'installation, visitez l'application et connectez-vous avec les identifiants ci-dessus.
 
         **✨ Fonctionnalités disponibles :**
         • Diviser, fusionner et organiser les PDF
@@ -296,8 +314,12 @@ x-casaos:
         **⏰ Tiempo de configuración:**
         Esta aplicación toma aproximadamente 5-10 minutos para configurarse después de la instalación. Por favor ten paciencia y espera antes de intentar acceder.
 
-        **🔓 Sin inicio de sesión requerido:**
-        Esta aplicación está configurada sin autenticación para un acceso más fácil. Todo el procesamiento de PDF ocurre localmente en tu servidor. (Ver rationale.md para justificación de seguridad)
+        **🔒 Inicio de sesión requerido:**
+        Esta aplicación tiene protección de inicio de sesión integrada por seguridad.
+        • Usuario: `admin`
+        • Contraseña: Generada automáticamente (igual que $default_pwd)
+
+        Después de la instalación, visita la aplicación e inicia sesión con las credenciales anteriores.
 
         **✨ Características disponibles:**
         • Dividir, combinar y organizar PDFs
@@ -320,4 +342,4 @@ x-casaos:
 
         **Cómo usar:**
         ¡Sube archivos PDF a través de tu navegador web y comienza a editarlos de inmediato!
-  index: /
+  index: /login

--- a/Apps/Stirling-PDF/docker-compose.yml
+++ b/Apps/Stirling-PDF/docker-compose.yml
@@ -5,10 +5,11 @@ services:
     image: docker.stirlingpdf.com/stirlingtools/stirling-pdf:2.4.3
     container_name: stirling-pdf
     restart: unless-stopped
-    networks:
-      - pcs
     expose:
       - 80
+    labels:
+      - "caddy=stirlingpdf-${APP_DOMAIN}"
+      - "caddy.reverse_proxy={{upstreams 80}}"
     volumes:
       - /DATA/AppData/$AppID/tessdata/:/usr/share/tessdata
       - /DATA/AppData/$AppID/configs/:/configs
@@ -25,9 +26,9 @@ services:
       DOCKER_ENABLE_SECURITY: true
       SECURITY_ENABLELOGIN: true
       SECURITY_INITIALLOGIN_USERNAME: admin
-      SECURITY_INITIALLOGIN_PASSWORD: $default_pwd
+      SECURITY_INITIALLOGIN_PASSWORD: $PCS_DEFAULT_PASSWORD
       DISABLE_ADDITIONAL_FEATURES: true
-      SYSTEM_DEFAULTLOCALE: $TZ
+      SYSTEM_DEFAULTLOCALE: en_US
       INSTALL_BOOK_AND_ADVANCED_HTML_OPS: false
       TMPDIR: /tmp
       # Optimized Java memory management - prevents OOM errors and improves stability
@@ -42,10 +43,6 @@ services:
           memory: 2G  # Reserve minimum memory
     cpu_shares: 50  # Standard application priority
 
-networks:
-  pcs:
-    external: true
-
 x-casaos:
   architectures:
     - amd64
@@ -55,6 +52,12 @@ x-casaos:
   author: Yundera Team
   category: Office
   developer: Stirling Tools
+  pre-install-cmd: |
+    docker run --rm -v /DATA/AppData/$AppID:/data ubuntu:22.04 sh -c '
+      mkdir -p /data/tessdata /data/configs /data/logs /data/customFiles /data/pipeline /data/tmp &&
+      chmod -R 777 /data &&
+      echo "Directories created and permissions set successfully"
+    '
   description:
     en_us: |
       **Your complete PDF toolkit - everything you need to work with PDF files, right from your web browser.**
@@ -187,11 +190,9 @@ x-casaos:
         This app takes about 5-10 minutes to set up after installation. Please be patient and wait before trying to access it.
 
         **🔒 Login Required:**
-        This app has built-in login protection for security.
-        • Username: `admin`
-        • Password: Auto-generated (same as $default_pwd)
-
-        After installation, visit the app and log in with the credentials above.
+        | Username | Password |
+        | -------- | -------- |
+        | `admin`  | `$PCS_DEFAULT_PASSWORD` |
 
         **✨ Features Available:**
         • Split, merge, and organize PDFs
@@ -202,7 +203,7 @@ x-casaos:
         • Compress PDFs to reduce file size
 
         **🌐 Access:**
-        Once ready, your app will be available at `https://stirlingpdf-[username].nsl.sh`
+        Once ready, your app will be available at `https://stirlingpdf-username.nsl.sh`
 
         **💡 New in V2.4.3:**
         • Stateful Processing - Upload once, use across multiple tools
@@ -219,11 +220,9 @@ x-casaos:
         이 앱은 설치 후 설정이 완료되기까지 약 5-10분이 걸립니다. 인내심을 갖고 접속하기 전에 기다려 주세요.
 
         **🔒 로그인 필요:**
-        이 앱은 보안을 위해 내장 로그인으로 보호됩니다.
-        • 사용자명: `admin`
-        • 비밀번호: 자동 생성됨 ($default_pwd와 동일)
-
-        설치 후 앱을 방문하여 위 자격 증명으로 로그인하세요.
+        | 사용자명 | 비밀번호 |
+        | -------- | -------- |
+        | `admin`  | `$PCS_DEFAULT_PASSWORD` |
 
         **✨ 사용 가능한 기능:**
         • PDF 분할, 병합, 정리
@@ -234,7 +233,7 @@ x-casaos:
         • PDF 압축으로 파일 크기 줄이기
 
         **🌐 접근:**
-        준비가 되면 `https://stirlingpdf-[username].nsl.sh`로 앱에 접근할 수 있습니다!
+        준비가 되면 `https://stirlingpdf-username.nsl.sh`로 앱에 접근할 수 있습니다!
 
         **💡 V2.4.3 새로운 기능:**
         • Stateful Processing - 한 번 업로드로 여러 도구에서 사용
@@ -251,11 +250,9 @@ x-casaos:
         此应用在安装后需要约5-10分钟来完成设置。请耐心等待,在尝试访问之前请等待。
 
         **🔒 需要登录:**
-        此应用具有内置登录保护以确保安全。
-        • 用户名：`admin`
-        • 密码：自动生成（与$default_pwd相同）
-
-        安装后，访问应用并使用上述凭据登录。
+        | 用户名 | 密码 |
+        | ------ | ---- |
+        | `admin` | `$PCS_DEFAULT_PASSWORD` |
 
         **✨ 可用功能:**
         • PDF拆分、合并和整理
@@ -266,7 +263,7 @@ x-casaos:
         • 压缩PDF以减少文件大小
 
         **🌐 访问:**
-        准备就绪后,您的应用将通过`https://stirlingpdf-[username].nsl.sh`可用!
+        准备就绪后,您的应用将通过`https://stirlingpdf-username.nsl.sh`可用!
 
         **💡 V2.4.3 新功能:**
         • 状态处理 - 上传一次,跨多个工具使用
@@ -283,11 +280,9 @@ x-casaos:
         Cette application prend environ 5-10 minutes pour s'installer après l'installation. Veuillez être patient et attendre avant d'essayer d'y accéder.
 
         **🔒 Connexion requise :**
-        Cette application dispose d'une protection de connexion intégrée pour la sécurité.
-        • Nom d'utilisateur : `admin`
-        • Mot de passe : Généré automatiquement (identique à $default_pwd)
-
-        Après l'installation, visitez l'application et connectez-vous avec les identifiants ci-dessus.
+        | Nom d'utilisateur | Mot de passe |
+        | ----------------- | ------------ |
+        | `admin` | `$PCS_DEFAULT_PASSWORD` |
 
         **✨ Fonctionnalités disponibles :**
         • Diviser, fusionner et organiser les PDF
@@ -298,7 +293,7 @@ x-casaos:
         • Compresser les PDF pour réduire la taille
 
         **🌐 Accès :**
-        Une fois prêt, votre application sera disponible à `https://stirlingpdf-[username].nsl.sh` !
+        Une fois prêt, votre application sera disponible à `https://stirlingpdf-username.nsl.sh` !
 
         **💡 Nouveautés V2.4.3 :**
         • Traitement avec état - Téléchargez une fois, utilisez sur plusieurs outils
@@ -315,11 +310,9 @@ x-casaos:
         Esta aplicación toma aproximadamente 5-10 minutos para configurarse después de la instalación. Por favor ten paciencia y espera antes de intentar acceder.
 
         **🔒 Inicio de sesión requerido:**
-        Esta aplicación tiene protección de inicio de sesión integrada por seguridad.
-        • Usuario: `admin`
-        • Contraseña: Generada automáticamente (igual que $default_pwd)
-
-        Después de la instalación, visita la aplicación e inicia sesión con las credenciales anteriores.
+        | Usuario | Contraseña |
+        | ------- | ---------- |
+        | `admin` | `$PCS_DEFAULT_PASSWORD` |
 
         **✨ Características disponibles:**
         • Dividir, combinar y organizar PDFs
@@ -330,7 +323,7 @@ x-casaos:
         • Comprimir PDFs para reducir el tamaño
 
         **🌐 Acceso:**
-        Una vez listo, tu aplicación estará disponible en `https://stirlingpdf-[username].nsl.sh`!
+        Una vez listo, tu aplicación estará disponible en `https://stirlingpdf-username.nsl.sh`!
 
         **💡 Novedades V2.4.3:**
         • Procesamiento con estado - Sube una vez, usa en múltiples herramientas

--- a/Apps/Stirling-PDF/docker-compose.yml
+++ b/Apps/Stirling-PDF/docker-compose.yml
@@ -20,8 +20,8 @@ services:
       - /DATA/AppData/$AppID/tmp/:/tmp
     user: "0:0"  # Root user required for Java runtime and PDF tools - see rationale.md
     environment:
-      PGID: 0
-      PUID: 0
+      PGID: $PGID
+      PUID: $PUID
       TZ: $TZ
       DOCKER_ENABLE_SECURITY: true
       SECURITY_ENABLELOGIN: true
@@ -33,7 +33,7 @@ services:
       TMPDIR: /tmp
       # Optimized Java memory management - prevents OOM errors and improves stability
       JAVA_TOOL_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:MaxRAMPercentage=70 -XX:InitialRAMPercentage=40 -XX:MinRAMPercentage=30 -XX:+UseG1GC -XX:+UseStringDeduplication -XX:G1PeriodicGCInterval=30000 -XX:MaxGCPauseMillis=200 -XX:+ParallelRefProcEnabled -Djava.io.tmpdir=/tmp"
-      SERVER_PORT: 80  # Run on port 80 for NSL router compatibility
+      SERVER_PORT: 80  # Run on port 80 for Caddy reverse proxy
     deploy:
       resources:
         limits:
@@ -41,23 +41,24 @@ services:
           cpus: '1.0'  # Increased from 1.0 for better performance
         reservations:
           memory: 2G  # Reserve minimum memory
-    cpu_shares: 50  # Standard application priority
+    networks:
+      - pcs
+    cpu_shares: 70  # Interactive + Heavy Tasks (PDF conversion, OCR, compression)
+
+networks:
+  pcs:
+    external: true
 
 x-casaos:
   architectures:
     - amd64
     - arm64
   main: stirlingpdf
+  store_app_id: stirlingpdf
   webui_port: 80
   author: Yundera Team
   category: Office
   developer: Stirling Tools
-  pre-install-cmd: |
-    docker run --rm -v /DATA/AppData/$AppID:/data ubuntu:22.04 sh -c '
-      mkdir -p /data/tessdata /data/configs /data/logs /data/customFiles /data/pipeline /data/tmp &&
-      chmod -R 777 /data &&
-      echo "Directories created and permissions set successfully"
-    '
   description:
     en_us: |
       **Your complete PDF toolkit - everything you need to work with PDF files, right from your web browser.**

--- a/Apps/Stirling-PDF/docker-compose.yml
+++ b/Apps/Stirling-PDF/docker-compose.yml
@@ -2,22 +2,30 @@ name: stirlingpdf
 
 services:
   stirlingpdf:
-    image: docker.stirlingpdf.com/stirlingtools/stirling-pdf:2.5.2
+    image: docker.stirlingpdf.com/stirlingtools/stirling-pdf:2.8.0
     container_name: stirling-pdf
     restart: unless-stopped
     expose:
       - 80
     labels:
-      - "caddy=stirlingpdf-${APP_DOMAIN}"
-      - "caddy.reverse_proxy={{upstreams 80}}"
+      caddy_0: stirlingpdf-${APP_DOMAIN}
+      caddy_0.import: gateway_tls
+      caddy_0.reverse_proxy: "{{upstreams 80}}"
+      caddy_1: stirlingpdf-${APP_PUBLIC_IP_DASH}.nip.io
+      caddy_1.import: gateway_tls
+      caddy_1.reverse_proxy: "{{upstreams 80}}"
+      caddy_2: stirlingpdf-${APP_PUBLIC_IP_DASH}.sslip.io
+      caddy_2.reverse_proxy: "{{upstreams 80}}"
+    networks:
+      - pcs
     volumes:
-      - /DATA/AppData/$AppID/tessdata/:/usr/share/tessdata
-      - /DATA/AppData/$AppID/configs/:/configs
-      - /DATA/AppData/$AppID/logs/:/logs
-      - /DATA/AppData/$AppID/customFiles/:/customFiles
-      - /DATA/AppData/$AppID/pipeline/:/pipeline
-      - /DATA/Downloads/:/downloads
-      - /DATA/AppData/$AppID/tmp/:/tmp
+      - /DATA/AppData/$AppID/tessdata/:/usr/share/tessdata/
+      - /DATA/AppData/$AppID/configs/:/configs/
+      - /DATA/AppData/$AppID/logs/:/logs/
+      - /DATA/AppData/$AppID/customFiles/:/customFiles/
+      - /DATA/AppData/$AppID/pipeline/:/pipeline/
+      - /DATA/Downloads/:/downloads/
+      - /DATA/AppData/$AppID/tmp/:/tmp/
     user: "0:0"  # Root user required for Java runtime and PDF tools - see rationale.md
     environment:
       PGID: 0
@@ -26,7 +34,7 @@ services:
       DOCKER_ENABLE_SECURITY: true
       SECURITY_ENABLELOGIN: true
       SECURITY_INITIALLOGIN_USERNAME: admin
-      SECURITY_INITIALLOGIN_PASSWORD: $PCS_DEFAULT_PASSWORD
+      SECURITY_INITIALLOGIN_PASSWORD: $APP_DEFAULT_PASSWORD
       DISABLE_ADDITIONAL_FEATURES: true
       SYSTEM_DEFAULTLOCALE: en_US
       INSTALL_BOOK_AND_ADVANCED_HTML_OPS: false
@@ -43,6 +51,11 @@ services:
           memory: 2G  # Reserve minimum memory
     cpu_shares: 50  # Standard application priority
 
+networks:
+  pcs:
+    name: pcs
+    external: true
+
 x-casaos:
   architectures:
     - amd64
@@ -52,12 +65,6 @@ x-casaos:
   author: Yundera Team
   category: Office
   developer: Stirling Tools
-  pre-install-cmd: |
-    docker run --rm -v /DATA/AppData/$AppID:/data ubuntu:22.04 sh -c '
-      mkdir -p /data/tessdata /data/configs /data/logs /data/customFiles /data/pipeline /data/tmp &&
-      chmod -R 777 /data &&
-      echo "Directories created and permissions set successfully"
-    '
   description:
     en_us: |
       **Your complete PDF toolkit - everything you need to work with PDF files, right from your web browser.**
@@ -192,7 +199,7 @@ x-casaos:
         **🔒 Login Required:**
         | Username | Password |
         | -------- | -------- |
-        | `admin`  | `$PCS_DEFAULT_PASSWORD` |
+        | `admin`  | `$APP_DEFAULT_PASSWORD` |
 
         **✨ Features Available:**
         • Split, merge, and organize PDFs
@@ -205,13 +212,13 @@ x-casaos:
         **🌐 Access:**
         Once ready, your app will be available at `https://stirlingpdf-username.nsl.sh`
 
-        **💡 New in V2.4.3:**
-        • Stateful Processing - Upload once, use across multiple tools
-        • Undo & Redo with full version history
-        • 2FA support and enhanced security
-        • Improved page editor performance and UI
-        • PDF/X format support and better conversion tools
-        • Enhanced memory management (5GB limit with 2GB reservation)
+        **💡 New in V2.8.0:**
+        • PDF Commenting - View and add comments to PDFs
+        • RFC 3161 PDF Timestamps - Cryptographic timestamping for documents
+        • Enhanced PDF Rendering - Improved performance with Pdfium engine
+        • Advanced Multi-Page Layout - Expanded customization for page arrangements
+        • Desktop login removal - Authentication now optional
+        • Improved text selection and form handling
 
         **How to use:**
         Upload PDF files through your web browser and start editing them right away!
@@ -222,7 +229,7 @@ x-casaos:
         **🔒 로그인 필요:**
         | 사용자명 | 비밀번호 |
         | -------- | -------- |
-        | `admin`  | `$PCS_DEFAULT_PASSWORD` |
+        | `admin`  | `$APP_DEFAULT_PASSWORD` |
 
         **✨ 사용 가능한 기능:**
         • PDF 분할, 병합, 정리
@@ -235,13 +242,13 @@ x-casaos:
         **🌐 접근:**
         준비가 되면 `https://stirlingpdf-username.nsl.sh`로 앱에 접근할 수 있습니다!
 
-        **💡 V2.4.3 새로운 기능:**
-        • Stateful Processing - 한 번 업로드로 여러 도구에서 사용
-        • 실행 취소 및 다시 실행 (전체 버전 히스토리)
-        • 2FA 지원 및 향상된 보안
-        • 페이지 에디터 성능 및 UI 개선
-        • PDF/X 형식 지원 및 향상된 변환 도구
-        • 향상된 메모리 관리 (5GB 제한, 2GB 예약)
+        **💡 V2.8.0 새로운 기능:**
+        • PDF 댓글 - PDF에 댓글 보기 및 추가
+        • RFC 3161 PDF 타임스탬프 - 문서에 대한 암호화 타임스탬프
+        • 향상된 PDF 렌더링 - Pdfium 엔진으로 성능 개선
+        • 고급 다중 페이지 레이아웃 - 페이지 배열 사용자 정의 확장
+        • 데스크톱 로그인 제거 - 인증이 이제 선택 사항
+        • 향상된 텍스트 선택 및 양식 처리
 
         **사용 방법:**
         웹 브라우저를 통해 PDF 파일을 업로드하고 바로 편집을 시작할 수 있습니다!
@@ -252,7 +259,7 @@ x-casaos:
         **🔒 需要登录:**
         | 用户名 | 密码 |
         | ------ | ---- |
-        | `admin` | `$PCS_DEFAULT_PASSWORD` |
+        | `admin` | `$APP_DEFAULT_PASSWORD` |
 
         **✨ 可用功能:**
         • PDF拆分、合并和整理
@@ -265,13 +272,13 @@ x-casaos:
         **🌐 访问:**
         准备就绪后,您的应用将通过`https://stirlingpdf-username.nsl.sh`可用!
 
-        **💡 V2.4.3 新功能:**
-        • 状态处理 - 上传一次,跨多个工具使用
-        • 撤销和重做(完整版本历史)
-        • 2FA支持和增强安全性
-        • 页面编辑器性能和UI改进
-        • PDF/X格式支持和更好的转换工具
-        • 增强的内存管理(5GB限制,2GB保留)
+        **💡 V2.8.0 新功能:**
+        • PDF评论 - 查看和添加PDF评论
+        • RFC 3161 PDF时间戳 - 文档加密时间戳
+        • 增强PDF渲染 - 使用Pdfium引擎提升性能
+        • 高级多页面布局 - 扩展页面排列自定义选项
+        • 桌面登录移除 - 身份验证现在可选
+        • 改进的文本选择和表单处理
 
         **如何使用:**
         通过网页浏览器上传PDF文件并立即开始编辑!
@@ -282,7 +289,7 @@ x-casaos:
         **🔒 Connexion requise :**
         | Nom d'utilisateur | Mot de passe |
         | ----------------- | ------------ |
-        | `admin` | `$PCS_DEFAULT_PASSWORD` |
+        | `admin` | `$APP_DEFAULT_PASSWORD` |
 
         **✨ Fonctionnalités disponibles :**
         • Diviser, fusionner et organiser les PDF
@@ -295,13 +302,13 @@ x-casaos:
         **🌐 Accès :**
         Une fois prêt, votre application sera disponible à `https://stirlingpdf-username.nsl.sh` !
 
-        **💡 Nouveautés V2.4.3 :**
-        • Traitement avec état - Téléchargez une fois, utilisez sur plusieurs outils
-        • Annuler et rétablir (historique complet des versions)
-        • Support 2FA et sécurité améliorée
-        • Performance et UI de l'éditeur de pages améliorées
-        • Support du format PDF/X et meilleurs outils de conversion
-        • Gestion mémoire améliorée (limite 5GB avec réservation 2GB)
+        **💡 Nouveautés V2.8.0 :**
+        • Commentaires PDF - Afficher et ajouter des commentaires aux PDF
+        • Horodatage PDF RFC 3161 - Horodatage cryptographique des documents
+        • Rendu PDF amélioré - Performance accrue avec le moteur Pdfium
+        • Mise en page multi-pages avancée - Options de personnalisation étendues
+        • Suppression de la connexion bureau - Authentification désormais optionnelle
+        • Sélection de texte et gestion des formulaires améliorées
 
         **Comment utiliser :**
         Téléchargez des fichiers PDF via votre navigateur web et commencez à les éditer immédiatement !
@@ -312,7 +319,7 @@ x-casaos:
         **🔒 Inicio de sesión requerido:**
         | Usuario | Contraseña |
         | ------- | ---------- |
-        | `admin` | `$PCS_DEFAULT_PASSWORD` |
+        | `admin` | `$APP_DEFAULT_PASSWORD` |
 
         **✨ Características disponibles:**
         • Dividir, combinar y organizar PDFs
@@ -325,13 +332,13 @@ x-casaos:
         **🌐 Acceso:**
         Una vez listo, tu aplicación estará disponible en `https://stirlingpdf-username.nsl.sh`!
 
-        **💡 Novedades V2.4.3:**
-        • Procesamiento con estado - Sube una vez, usa en múltiples herramientas
-        • Deshacer y rehacer (historial completo de versiones)
-        • Soporte 2FA y seguridad mejorada
-        • Rendimiento y UI del editor de páginas mejorados
-        • Soporte de formato PDF/X y mejores herramientas de conversión
-        • Gestión de memoria mejorada (límite 5GB con reserva 2GB)
+        **💡 Novedades V2.8.0:**
+        • Comentarios PDF - Ver y agregar comentarios a PDFs
+        • Marcas de tiempo PDF RFC 3161 - Sellado criptográfico de documentos
+        • Renderizado PDF mejorado - Mayor rendimiento con el motor Pdfium
+        • Diseño multi-página avanzado - Opciones de personalización ampliadas
+        • Eliminación de inicio de sesión de escritorio - Autenticación ahora opcional
+        • Selección de texto y manejo de formularios mejorados
 
         **Cómo usar:**
         ¡Sube archivos PDF a través de tu navegador web y comienza a editarlos de inmediato!

--- a/Apps/Stirling-PDF/docker-compose.yml
+++ b/Apps/Stirling-PDF/docker-compose.yml
@@ -2,7 +2,7 @@ name: stirlingpdf
 
 services:
   stirlingpdf:
-    image: docker.stirlingpdf.com/stirlingtools/stirling-pdf:2.4.3
+    image: docker.stirlingpdf.com/stirlingtools/stirling-pdf:2.5.2
     container_name: stirling-pdf
     restart: unless-stopped
     expose:

--- a/Apps/Stirling-PDF/docker-compose.yml
+++ b/Apps/Stirling-PDF/docker-compose.yml
@@ -20,8 +20,8 @@ services:
       - /DATA/AppData/$AppID/tmp/:/tmp
     user: "0:0"  # Root user required for Java runtime and PDF tools - see rationale.md
     environment:
-      PGID: $PGID
-      PUID: $PUID
+      PGID: 0
+      PUID: 0
       TZ: $TZ
       DOCKER_ENABLE_SECURITY: true
       SECURITY_ENABLELOGIN: true
@@ -33,7 +33,7 @@ services:
       TMPDIR: /tmp
       # Optimized Java memory management - prevents OOM errors and improves stability
       JAVA_TOOL_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:MaxRAMPercentage=70 -XX:InitialRAMPercentage=40 -XX:MinRAMPercentage=30 -XX:+UseG1GC -XX:+UseStringDeduplication -XX:G1PeriodicGCInterval=30000 -XX:MaxGCPauseMillis=200 -XX:+ParallelRefProcEnabled -Djava.io.tmpdir=/tmp"
-      SERVER_PORT: 80  # Run on port 80 for Caddy reverse proxy
+      SERVER_PORT: 80  # Run on port 80 for NSL router compatibility
     deploy:
       resources:
         limits:
@@ -41,24 +41,23 @@ services:
           cpus: '1.0'  # Increased from 1.0 for better performance
         reservations:
           memory: 2G  # Reserve minimum memory
-    networks:
-      - pcs
-    cpu_shares: 70  # Interactive + Heavy Tasks (PDF conversion, OCR, compression)
-
-networks:
-  pcs:
-    external: true
+    cpu_shares: 50  # Standard application priority
 
 x-casaos:
   architectures:
     - amd64
     - arm64
   main: stirlingpdf
-  store_app_id: stirlingpdf
   webui_port: 80
   author: Yundera Team
   category: Office
   developer: Stirling Tools
+  pre-install-cmd: |
+    docker run --rm -v /DATA/AppData/$AppID:/data ubuntu:22.04 sh -c '
+      mkdir -p /data/tessdata /data/configs /data/logs /data/customFiles /data/pipeline /data/tmp &&
+      chmod -R 777 /data &&
+      echo "Directories created and permissions set successfully"
+    '
   description:
     en_us: |
       **Your complete PDF toolkit - everything you need to work with PDF files, right from your web browser.**


### PR DESCRIPTION
## Update Stirling-PDF v2.4.3 - Add Built-in Login Authentication

### Description

Adds Stirling-PDF's built-in login authentication to improve security. Previously the app was configured without authentication, relying solely on network-level access control.

### What Changed

**Authentication Enabled:**
- `DOCKER_ENABLE_SECURITY: true`
- `SECURITY_ENABLELOGIN: true`
- `SECURITY_INITIALLOGIN_USERNAME: admin`
- `SECURITY_INITIALLOGIN_PASSWORD: $PCS_DEFAULT_PASSWORD`
- Index page changed to `/login`

**Why:**
- Adds an additional security layer beyond network-level access
- Uses `$PCS_DEFAULT_PASSWORD` per CONTRIBUTING.md standards
- Users can change credentials after first login

### Security Checklist
- [x] Default authentication enabled with `$PCS_DEFAULT_PASSWORD` (no hardcoded credentials)
- [x] Login credentials documented in tips (all 5 languages)
- [x] Root user (`0:0`) justified in rationale.md - required for Java runtime and PDF tools
- [x] Specific version tag: `2.4.3`
- [x] pre-install-cmd uses specific version tag (`ubuntu:22.04`)

### Functionality Checklist
- [x] Works immediately after installation
- [x] Data mapped to `/DATA/AppData/$AppID/` and `/DATA/Downloads/`
- [x] cpu_shares: 50 (Standard Application)
- [x] Resource limits: 5G memory (2G reservation), 1.0 CPU
- [x] Fresh installation tested
- [x] Uninstall/reinstall tested - data persists

### Documentation Checklist
- [x] Description in 5 languages (en_us, ko_kr, zh_cn, fr_fr, es_es)
- [x] Tips updated with login credentials table in all 5 languages
- [x] Icon, screenshots, thumbnail point to Yundera/AppStore@main

### Testing
- ✅ Login page appears on first access
- ✅ admin / $PCS_DEFAULT_PASSWORD authentication working
- ✅ Session persistence after login
- ✅ All PDF operations functional after authentication
- ✅ Password change via admin panel verified

### Links
- [Official Repository](https://github.com/Stirling-Tools/Stirling-PDF)
- [Release v2.4.3](https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v2.4.3)
