### PR TITLE
Update Suwayomi manga reader app v2.1.2087

### DIFF
--- a/Apps/Suwayomi/docker-compose.yml
+++ b/Apps/Suwayomi/docker-compose.yml
@@ -73,7 +73,7 @@ x-casaos:
   index: /
   store_app_id: suwayomi
   pre-install-cmd: |
-    mkdir -p /DATA/AppData/suwayomi/data &&
+    mkdir -p /DATA/AppData/$AppID/data &&
     mkdir -p /DATA/Media/Mangas
   architectures:
     - amd64

--- a/Apps/Suwayomi/docker-compose.yml
+++ b/Apps/Suwayomi/docker-compose.yml
@@ -59,6 +59,8 @@ services:
       resources:
         limits:
           memory: 512M
+    networks:
+      - pcs
 
 networks:
   pcs:
@@ -67,6 +69,7 @@ networks:
 
 x-casaos:
   main: suwayomi
+  webui_port: 80
   index: /
   store_app_id: suwayomi
   pre-install-cmd: |

--- a/Apps/Suwayomi/docker-compose.yml
+++ b/Apps/Suwayomi/docker-compose.yml
@@ -73,8 +73,8 @@ x-casaos:
   index: /
   store_app_id: suwayomi
   pre-install-cmd: |
-    mkdir -p /DATA/AppData/$AppID/data &&
-    mkdir -p /DATA/Media/Mangas
+    mkdir -p /DATA/AppData/$AppID/data /DATA/Media/Mangas &&
+    chown -R $PUID:$PGID /DATA/AppData/$AppID /DATA/Media/Mangas
   architectures:
     - amd64
     - arm64


### PR DESCRIPTION
## Summary
Update Suwayomi (v2.1.2087) with Yundera AppStore conventions — Caddy reverse proxy, resource limits, cpu_shares, FlareSolverr, multi-language metadata.

## Architecture
| Service | Image | cpu_shares |
|---------|-------|-----------|
| suwayomi | ghcr.io/suwayomi/tachidesk:v2.1.2087 | 70 |
| flaresolverr | ghcr.io/flaresolverr/flaresolverr:v3.4.6 | 30 |

- Internal network: `suwayomi-network` (bridge)
- External network: `pcs` (Caddy reverse proxy)

## Submission Checklist

### Tech Checklist
- [x] Proper file permissions — `user: 0:0`, volumes mapped to `/DATA/AppData/$AppID/`
- [x] Migration path — Suwayomi handles DB migrations on startup
- [x] Pre-install/post-install commands security — uses specific version tags, idempotent

### Security Checklist
- [x] Default authentication — basic auth configured with `$PCS_DEFAULT_PASSWORD`
- [x] No hardcoded credentials — uses `$PCS_DEFAULT_PASSWORD`
- [x] Specific version tags — `tachidesk:v2.1.2087`, `flaresolverr:v3.4.6`

### Functionality Checklist
- [x] Works immediately after installation
- [x] Data mapped to `/DATA/AppData/$AppID/data`
- [x] No manual configuration required
- [x] Data persistence — manga library and progress persist
- [x] cpu_shares set on all services — suwayomi: 70, flaresolverr: 30
- [x] Fresh installation tested
- [x] Uninstall/reinstall tested

### Documentation Checklist
- [x] Clear description — en_us, ko_kr, zh_cn, fr_fr, es_es
- [x] Tagline in 5 languages
- [x] Icon and screenshots provided, CDN URLs point to `Yundera/AppStore@main`
